### PR TITLE
Fix: a possible memory leak + inconsistent use of caml_stat_* functions

### DIFF
--- a/lib/pcre_stubs.c
+++ b/lib/pcre_stubs.c
@@ -187,7 +187,7 @@ static void pcre_dealloc_regexp(value v_rex)
 {
   void *extra = (void *) Field(v_rex, 2);
   (pcre_free)((void *) Field(v_rex, 1));
-  if (extra != NULL) (pcre_free)(extra);
+  if (extra != NULL) pcre_free_study(extra);
 }
 
 /* Makes OCaml-string from PCRE-version */
@@ -306,7 +306,7 @@ CAMLprim value pcre_set_imp_match_limit_recursion_stub(value v_rex, value v_lim)
 {
   pcre_extra *extra = (pcre_extra *) Field(v_rex, 2);
   if (extra == NULL) {
-    extra = caml_stat_alloc(sizeof(pcre_extra));
+    extra = pcre_malloc(sizeof(pcre_extra));
     extra->flags = PCRE_EXTRA_MATCH_LIMIT_RECURSION;
     Field(v_rex, 2) = (value) extra;
   } else {
@@ -336,7 +336,7 @@ CAMLprim value pcre_set_imp_match_limit_stub(value v_rex, value v_lim)
 {
   pcre_extra *extra = (pcre_extra *) Field(v_rex, 2);
   if (extra == NULL) {
-    extra = caml_stat_alloc(sizeof(pcre_extra));
+    extra = pcre_malloc(sizeof(pcre_extra));
     extra->flags = PCRE_EXTRA_MATCH_LIMIT;
     Field(v_rex, 2) = (value) extra;
   } else {


### PR DESCRIPTION
One more patch from the "inconsistencies" series:

> Hello. I'm doing a large-scale study of C stub sources on OPAM.
>
> Your library makes use of the undocumented `caml_stat_*` functions, which currently are thin wrappers around `malloc`, `realloc`, and `free` from the C standard library. In future, the implementation of these functions [may change](https://github.com/ocaml/ocaml/pull/71), making them incompatible with `malloc` and breaking the code that abused the old undocumented semantics.
>
> Regardless of whether the change of semantics will happen or not, being consistent about such matters should be considered good style.

Explanation:
1) `pcre_free` expects a block allocated with `pcre_malloc` (which usually happens to be the same as `malloc`, but is not guaranteed to be so).
2) In comparison to `pcre_free`, `pcre_free_study` ensures that any JIT data is also freed. So, this potentially fixes a memory leak.