### PR TITLE
Add support for restartable DFA matching

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -26,3 +26,24 @@ Example invocation:
 ```sh
 subst '([Tt])ermcap' '$1ermCap' < /etc/termcap
 ```
+
+### dfa_restart
+
+Exercises the availability of the DFA matching function and its partial
+match restart capability. Given a pattern, will accept input incrementally,
+restarting the prior partial match until the pattern succeeds in matching
+completely, or fails.
+
+Example interaction:
+
+```
+$ dfa_restart.exe 'abc12+3'
+> abc
+partial match, provide more input:
+> 122222
+partial match, provide more input:
+> 222
+partial match, provide more input:
+> 3
+match completed: [0;1;0]
+```

--- a/examples/dfa_restart.ml
+++ b/examples/dfa_restart.ml
@@ -1,0 +1,36 @@
+
+open Pcre
+
+let () =
+  let open Printf in
+  let pat = if 1 = Array.length Sys.argv
+            then (eprintf "%s: expected pattern argument\n" Sys.argv.(0); exit 2)
+            else Sys.argv.(1) in
+  let rex = regexp pat in
+  let newWorkspace _ = Array.make 50 0 in
+  let showArray arr = Array.to_list arr
+                   |> List.map string_of_int
+                   |> String.concat ";"
+                   |> sprintf "[%s]" in
+  let read_line _ = try
+                      print_string "> "; Some (read_line ())
+                    with End_of_file -> None in
+  let rec restart _ = print_endline "\n *input & workspace reset*";
+                      findmatch [`PARTIAL] (newWorkspace ()) 
+  and findmatch flags workspace = 
+    match read_line() with
+      | None -> restart()
+      | Some input ->
+          try
+            let ret = pcre_dfa_exec ~rex ~flags ~workspace input in
+            printf "match completed: %s" @@ showArray ret;
+            restart()
+          with | Not_found -> printf "pattern match failed";
+                              restart()
+               | Error WorkspaceSize -> print_endline "need larger workspace vector";
+                                        exit 2
+               | Error InternalError s -> print_endline @@ "err: " ^ s;
+                                          exit 2
+               | Error Partial -> print_endline "partial match, provide more input:";
+                                  findmatch [`RESTART; `PARTIAL] workspace in
+  findmatch [`PARTIAL] (newWorkspace ())

--- a/examples/dune
+++ b/examples/dune
@@ -1,4 +1,4 @@
 (executables
-  (names cloc count_hash pcregrep subst)
+  (names cloc count_hash pcregrep subst dfa_restart)
   (libraries pcre)
 )


### PR DESCRIPTION
This is intended to eventually address #14.

I'm considering this a WIP for now, but things are fundamentally working, and I'd like to get some feedback so that the end result sits well with your general approach/tastes/etc. Topics for comment AFAICT now include:

* my approach of reusing `pcre_exec_stub` for both DFA and "regular" exec invocations
* the lack of higher-level functions for extracting matching substrings, etc. The primary use case for the DFA matching function is to support restartable partial matches, which at each step yield match offsets that are different from what functions accepting "`ovector`"s currently expect. To tie that knot, a function would be needed that would accept the sequence of `string`s provided that produced a full match and a sequence of the offset vectors returned from each step of the match; that could be the subject of a future enhancement if/when someone needed it (I may, eventually).

At a minimum before merging, I do want to:

* add reasonable documentation:
  * [x] for the additions to `pcre.mli`
  * [x] perhaps a DFA restart example for the README.
* ~~either enrich the return type of `pcre_dfa_exec` or add a utility function to examine the ovector returned from successful restarted DFA matches, and indicate what it means with regard to whether matching is complete or not. i.e. a partial DFA match can be in one of three states:~~
  1. ~~Partial and incomplete, when more input is needed to minimally satisfy the pattern, indicated by a `Partial` error.~~
  2. ~~Successful, when a pattern has been satisfied, and no additional input will begin or continue an additional partial match.~~
  3. ~~Successful _and_ partial, when a pattern has been satisfied, but additional input has been or may yet be supplied to begin or continue a partial match. This is possible only with trailing repetitions, and can only be distinguished from the second state by examining the returned ovector.~~

Of course, you may see other things that are worth rethinking or revising. 