### PR TITLE
Remove build dependency on Base

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,6 @@ substitution, similar to the functionality offered by the Perl language.")
     (dune (>= 1.10))
     dune-configurator
     (conf-libpcre :build)
-    (base :build)
     base-bytes
   )
 )

--- a/pcre.opam
+++ b/pcre.opam
@@ -22,6 +22,5 @@ depends: [
   "dune" {>= "1.10"}
   "dune-configurator"
   "conf-libpcre" {build}
-  "base" {build}
   "base-bytes"
 ]

--- a/src/config/discover.ml
+++ b/src/config/discover.ml
@@ -1,5 +1,3 @@
-open Base
-
 let () =
   let module C = Configurator.V1 in
   C.main ~name:"pcre" (fun c ->
@@ -7,9 +5,10 @@ let () =
       libs = ["-lpcre"];
       cflags = []
     } in
-    let conf =
-      Option.value_map (C.Pkg_config.get c) ~default ~f:(fun pc ->
-        Option.value (C.Pkg_config.query pc ~package:"libpcre") ~default)
+    let conf = match C.Pkg_config.get c with
+      | None -> default
+      | Some pc ->
+         Option.value (C.Pkg_config.query pc ~package:"libpcre") ~default
     in
     C.Flags.write_sexp "c_flags.sexp" conf.cflags;
     C.Flags.write_sexp "c_library_flags.sexp" conf.libs)


### PR DESCRIPTION
I removed the build dependency on base, which was rather frivolous, to be honest. (I'm using this library for one of my own projects and wish to reduce unnecessary dependencies.)

You don't have to accept this PR, of course, but I personally believe that if the dependency isn't necessary, less dependencies are better. In this case, the purpose of Base is easily accomplished using the standard library.

Thank you for your time!