### PR TITLE
Remove base library from config/dune

### DIFF
--- a/src/config/dune
+++ b/src/config/dune
@@ -1,4 +1,4 @@
 (executables
   (names discover)
-  (libraries base dune.configurator)
+  (libraries dune.configurator)
 )


### PR DESCRIPTION
Oops, I realized that I forgot to remove base from the list of libraries in the dune file. I saw that the Travis build over at ocaml/opam-repository for your library failed because I had forgotten to make this change. Sorry. :(