### PR TITLE
Remove dependency on `base-bytes`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,6 +21,5 @@ substitution, similar to the functionality offered by the Perl language.")
     (ocaml (>= 4.12))
     dune-configurator
     (conf-libpcre :build)
-    base-bytes
   )
 )

--- a/pcre.opam
+++ b/pcre.opam
@@ -15,7 +15,6 @@ depends: [
   "ocaml" {>= "4.12"}
   "dune-configurator"
   "conf-libpcre" {build}
-  "base-bytes"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
This is only required to get the META file for `bytes` but given the library is not used in the codebase, no need for it.

This decreases the dependency cone.