### PR TITLE
let's use this PR to discuss adding tests ?

### DIFF
--- a/pa_ppx_test/Makefile
+++ b/pa_ppx_test/Makefile
@@ -1,0 +1,9 @@
+NOT_OCAMLFIND=not-ocamlfind
+
+bootstrap: ../test/pcre_tests.ml
+
+../test/%.ml: %.ml
+	$(NOT_OCAMLFIND) preprocess -package pa_ppx_regexp,camlp5.pr_o -ppopt -pa_ppx_regexp-nostatic -syntax camlp5o $< > $@.NEW && \
+	mv $@.NEW $@
+
+.SUFFIXES: .ml

--- a/pa_ppx_test/pcre_tests.ml
+++ b/pa_ppx_test/pcre_tests.ml
@@ -95,9 +95,13 @@ let test_pcre_subst ctxt =
   ; assert_equal "$$"  ([%subst "A(B)C" / {|$$|} / g i pcre] "abcabc")
 
 
+let show_string_option = function
+    None -> "None"
+  | Some s -> Printf.sprintf "Some %s" s
+
 let test_pcre_ocamlfind_bits ctxt =
   ()
-  ; assert_equal ~printer:[%show: string option] (Some "-syntax camlp5o ")
+  ; assert_equal ~printer:show_string_option (Some "-syntax camlp5o ")
       (snd ([%match {|^\(\*\*pp (.*?)\*\)|} / exc strings pcre]
        {|(**pp -syntax camlp5o *)
 |}))

--- a/pa_ppx_test/pcre_tests.ml
+++ b/pa_ppx_test/pcre_tests.ml
@@ -1,0 +1,156 @@
+(**pp -syntax camlp5o -package pa_ppx.deriving_plugins.std *)
+open OUnit2
+
+
+
+let test_special_char_regexps ctxt =
+  ()
+  ; assert_equal "\n"  ([%match {|\n$|}/s exc pcre strings] "\n")
+  ; assert_equal ""  ([%subst {|\n+$|} / {||} /s pcre] "\n\n")
+
+let test_pcre_simple_match ctxt =
+  ()
+  ; assert_equal "abc"  (Pcre.get_substring ([%match "abc"/exc raw pcre] "abc") 0)
+  ; assert_equal (Some "abc")  ([%match "abc"/pcre] "abc")
+  ; assert_equal (Some "abc")  ([%match "abc"/strings pcre] "abc")
+  ; assert_equal true  ([%match "abc"/pred pcre] "abc")
+  ; assert_equal false  ([%match "abc"/pred pcre] "abd")
+  ; assert_equal None  ([%match "abc"/pcre] "abd")
+  ; assert_raises Not_found (fun () -> [%match "abc"/exc pcre] "abd")
+  ; assert_raises Not_found (fun () -> [%match "abc"/exc strings pcre] "abd")
+  ; assert_equal None  ([%match "abc"/strings pcre] "abd")
+  ; assert_equal "abc"  ([%match "abc"/exc strings pcre] "abc")
+  ; assert_equal ("abc", Some "b")  ([%match "a(b)c"/exc strings pcre] "abc")
+  ; assert_equal ("ac", None)  ([%match "a(?:(b)?)c"/exc strings pcre] "ac")
+  ; assert_equal "abc"  (Pcre.get_substring ([%match "ABC"/exc raw i pcre] "abc") 0)
+  ; assert_equal ("abc", Some "a", Some "b", Some "c")  ([%match "(a)(b)(c)"/exc strings pcre] "abc")
+
+let test_pcre_selective_match ctxt =
+  ()
+  ; assert_equal ("abc", Some "b")  ([%match "a(b)c"/exc strings (!0,1) pcre] "abc")
+  ; assert_equal ("abc", "b")  ([%match "a(b)c"/exc strings (!0,!1) pcre] "abc")
+  ; assert_equal "b"  ([%match "a(b)c"/exc strings !1 pcre] "abc")
+  ; assert_equal (Some ("abc", "b"))  ([%match "a(b)c"/ strings (!0,!1) pcre] "abc")
+  ; assert_equal ("ac", None)  ([%match "a(b)?c"/exc strings (!0,1) pcre] "ac")
+  ; assert_raises Not_found  (fun _ -> [%match "a(b)?c"/exc strings (!0,!1) pcre] "ac")
+  ; assert_equal None  ([%match "a(b)?c"/ strings (!0,!1) pcre] "ac")
+
+let test_pcre_search ctxt =
+  ()
+  ; assert_equal "abc"  ([%match "abc"/exc strings pcre] "zzzabc")
+  ; assert_equal None  ([%match "^abc"/strings pcre] "zzzabc")
+
+
+let test_pcre_single ctxt =
+  ()
+  ; assert_equal None ([%match ".+"/pcre] "\n\n")
+  ; assert_equal "\n\n" ([%match ".+" / s exc pcre strings] "\n\n")
+  ; assert_equal None ([%match ".+" / m pcre strings] "\n\n")
+
+  ; assert_equal None ([%match ".+"/ pcre strings] "\n\n")
+  ; assert_equal (Some "\n\n") ([%match ".+"/s pcre strings] "\n\n")
+  ; assert_equal None ([%match ".+"/m pcre strings] "\n\n")
+
+  ; assert_equal "<<abc>>\ndef" ([%subst ".+" / {|<<$0>>|} / pcre] "abc\ndef")
+  ; assert_equal "<<abc\ndef>>" ([%subst ".+" / {|<<$0>>|}/s pcre] "abc\ndef")
+  ; assert_equal "<<abc>>\ndef" ([%subst ".+" / {|<<$0>>|}/m pcre] "abc\ndef")
+
+  ; assert_equal "<<abc>>\ndef"  ([%subst ".*" / {|<<$0>>|} /pcre] "abc\ndef")
+  ; assert_equal "<<abc>><<>>\n<<def>><<>>"  ([%subst ".*" / {|<<$0>>|} / g pcre] "abc\ndef")
+  ; assert_equal "<<abc>>\n<<def>>" ([%subst ".+" / {|<<$0>>|} / g pcre] "abc\ndef")
+  ; assert_equal "<<abc>>a\nc<<aec>>" ([%subst "a.c" / {|<<$0>>|} / g pcre] "abca\ncaec")
+  ; assert_equal "<<abc>><<a\nc>><<aec>>" ([%subst "a.c" / {|<<$0>>|} / g s pcre] "abca\ncaec")
+
+let test_pcre_multiline ctxt =
+  ()
+  ; assert_equal (Some "bar")  ([%match ".+$"/ strings pcre] "foo\nbar")
+  ; assert_equal (Some "foo")  ([%match ".+$"/ m strings pcre] "foo\nbar")
+
+let test_pcre_simple_split ctxt =
+  ()
+  ; assert_equal ["bb"]  ([%split "a"/pcre] "bb")
+
+
+let test_pcre_delim_split_raw ctxt =
+  let open Pcre in
+  ()
+  ; assert_equal [Delim "a"; Text "b"; Delim "a"; Text "b"] ([%split "a"/pcre raw] "ababa")
+  ; assert_equal [Delim "a"; Text "b"; Delim "a"; Delim "a"; Text "b"] ([%split "a"/pcre raw] "abaaba")
+  ; assert_equal [Delim "a"; NoGroup; Text "b"; Delim "ac"; Group (1, "c"); Text "b"; Delim "a"; NoGroup] ([%split "a(c)?"/pcre raw] "abacba")
+  ; assert_equal [Delim "ac"; Group (1, "c"); Text "b"; Delim "ac"; Group (1, "c"); Text "b"; Delim "ac"; Group (1, "c")] ([%split "a(c)"/pcre raw] "acbacbac")
+  ; assert_equal [Delim "ac"; Group (1, "c"); Text "b"; Delim "ac"; Group (1, "c"); Text "b"; Delim "ac"; Group (1, "c")] ([%split "a(c)"/pcre raw] "acbacbac")
+  ; assert_equal [Delim "a"; NoGroup; Text "b"; Delim "ac"; Group (1, "c"); Text "b"; Delim "a"; NoGroup] ([%split "a(c)?"/pcre raw] "abacba")
+  ; assert_equal [Text "ab"; Delim "x"; Group (1, "x"); NoGroup; Text "cd"] ([%split {|(x)|(u)|} / raw pcre] "abxcd")
+  ; assert_equal [Text "ab"; Delim "x"; Group (1, "x"); NoGroup; Text "cd"; Delim "u"; NoGroup; Group (2, "u")] ([%split {|(x)|(u)|} / raw pcre] "abxcdu")
+
+
+let test_pcre_string_pattern ctxt =
+  ()
+  ; assert_equal "$b"  ([%pattern {|$$$1|} /pcre] ([%match "a(b)c"/exc pcre raw] "abc"))
+  ; assert_equal "b"  ([%pattern {|${01}|} /pcre] ([%match "a(b)c"/exc pcre raw] "abc"))
+  ; assert_equal "bx"  (let s = "x" in [%pattern {|${01}${s}|} /pcre] ([%match "a(b)c"/exc pcre raw] "abc"))
+  ; assert_equal {|"bx|}  (let s = "x" in [%pattern {|"${01}${s}|} /pcre] ([%match "a(b)c"/exc pcre raw] "abc"))
+  ; assert_equal {|"x|}  (let s = "x" in [%pattern {|"${s}|} /pcre])
+
+
+let test_pcre_expr_pattern ctxt =
+  ()
+  ; assert_equal "abc"  ([%pattern "$0$" / e pcre] ([%match "abc"/exc pcre raw] "abc"))
+  ; assert_equal "abcx"  ([%pattern {|$0$ ^ "x"|} / e pcre] ([%match "abc"/exc pcre raw] "abc"))
+  ; assert_equal "abcx"  (let x = "x" in [%pattern {|$0$ ^ x|} / e pcre] ([%match "abc"/exc pcre raw] "abc"))
+  ; assert_equal "x"  (let x = "x" in [%pattern {|"" ^ x|} / e pcre])
+
+let test_pcre_subst ctxt =
+  ()
+  ; assert_equal "$b"  ([%subst "a(b)c" / {|$$$1|} /pcre] "abc")
+  ; assert_equal "$b"  ([%subst "A(B)C" / {|$$$1|} / i pcre] "abc")
+  ; assert_equal "$babc"  ([%subst "A(B)C" / {|$$$1|} / i pcre] "abcabc")
+  ; assert_equal "$b$b"  ([%subst "A(B)C" / {|$$$1|} / g i pcre] "abcabc")
+  ; assert_equal "$b$b"  ([%subst "A(B)C" / {|"$" ^ $1$|} / e g i pcre] "abcabc")
+  ; assert_equal "$$"  ([%subst "A(B)C" / {|"$"|} / e g i pcre] "abcabc")
+  ; assert_equal "$$"  ([%subst "A(B)C" / {|$$|} / g i pcre] "abcabc")
+
+
+let test_pcre_ocamlfind_bits ctxt =
+  ()
+  ; assert_equal ~printer:[%show: string option] (Some "-syntax camlp5o ")
+      (snd ([%match {|^\(\*\*pp (.*?)\*\)|} / exc strings pcre]
+       {|(**pp -syntax camlp5o *)
+|}))
+
+let pcre_envsubst envlookup s =
+  let f s1 s2 =
+    if s1 <> "" then envlookup s1
+    else if s2 <> "" then envlookup s2
+    else assert false in
+
+  [%subst {|(?:\$\(([^)]+)\)|\$\{([^}]+)\})|} / {| f $1$ $2$ |} / g e pcre] s
+
+let test_pcre_envsubst_via_replace ctxt =
+  let f = function "A" -> "res1" | "B" -> "res2" | _ -> failwith "unexpected arg in envsubst" in
+  assert_equal "...res1...res2..." (pcre_envsubst f {|...$(A)...${B}...|})
+
+
+
+
+
+let suite = "Test pa_ppx_regexp" >::: [
+      "pcre selective_match"   >:: test_pcre_selective_match
+    ; "pcre search"   >:: test_pcre_search
+    ; "pcre single"   >:: test_pcre_single
+    ; "pcre multiline"   >:: test_pcre_multiline
+    ; "pcre simple_split"   >:: test_pcre_simple_split
+    ; "pcre delim_split raw"   >:: test_pcre_delim_split_raw
+    ; "pcre string_pattern"   >:: test_pcre_string_pattern
+    ; "pcre expr_pattern"   >:: test_pcre_expr_pattern
+    ; "pcre subst"   >:: test_pcre_subst
+    ; "pcre ocamlfind bits"   >:: test_pcre_ocamlfind_bits
+    ; "pcre envsubst via replace"   >:: test_pcre_envsubst_via_replace
+    ; "pcre only_regexps"   >:: test_special_char_regexps
+    ]
+
+let _ = 
+if not !Sys.interactive then
+  run_test_tt_main suite
+else ()
+

--- a/pa_ppx_test/pcre_tests.ml
+++ b/pa_ppx_test/pcre_tests.ml
@@ -84,22 +84,6 @@ let test_pcre_delim_split_raw ctxt =
   ; assert_equal [Text "ab"; Delim "x"; Group (1, "x"); NoGroup; Text "cd"; Delim "u"; NoGroup; Group (2, "u")] ([%split {|(x)|(u)|} / raw pcre] "abxcdu")
 
 
-let test_pcre_string_pattern ctxt =
-  ()
-  ; assert_equal "$b"  ([%pattern {|$$$1|} /pcre] ([%match "a(b)c"/exc pcre raw] "abc"))
-  ; assert_equal "b"  ([%pattern {|${01}|} /pcre] ([%match "a(b)c"/exc pcre raw] "abc"))
-  ; assert_equal "bx"  (let s = "x" in [%pattern {|${01}${s}|} /pcre] ([%match "a(b)c"/exc pcre raw] "abc"))
-  ; assert_equal {|"bx|}  (let s = "x" in [%pattern {|"${01}${s}|} /pcre] ([%match "a(b)c"/exc pcre raw] "abc"))
-  ; assert_equal {|"x|}  (let s = "x" in [%pattern {|"${s}|} /pcre])
-
-
-let test_pcre_expr_pattern ctxt =
-  ()
-  ; assert_equal "abc"  ([%pattern "$0$" / e pcre] ([%match "abc"/exc pcre raw] "abc"))
-  ; assert_equal "abcx"  ([%pattern {|$0$ ^ "x"|} / e pcre] ([%match "abc"/exc pcre raw] "abc"))
-  ; assert_equal "abcx"  (let x = "x" in [%pattern {|$0$ ^ x|} / e pcre] ([%match "abc"/exc pcre raw] "abc"))
-  ; assert_equal "x"  (let x = "x" in [%pattern {|"" ^ x|} / e pcre])
-
 let test_pcre_subst ctxt =
   ()
   ; assert_equal "$b"  ([%subst "a(b)c" / {|$$$1|} /pcre] "abc")
@@ -141,8 +125,6 @@ let suite = "Test pa_ppx_regexp" >::: [
     ; "pcre multiline"   >:: test_pcre_multiline
     ; "pcre simple_split"   >:: test_pcre_simple_split
     ; "pcre delim_split raw"   >:: test_pcre_delim_split_raw
-    ; "pcre string_pattern"   >:: test_pcre_string_pattern
-    ; "pcre expr_pattern"   >:: test_pcre_expr_pattern
     ; "pcre subst"   >:: test_pcre_subst
     ; "pcre ocamlfind bits"   >:: test_pcre_ocamlfind_bits
     ; "pcre envsubst via replace"   >:: test_pcre_envsubst_via_replace

--- a/pcre.opam
+++ b/pcre.opam
@@ -16,6 +16,7 @@ depends: [
   "dune-configurator"
   "conf-libpcre" {build}
   "odoc" {with-doc}
+  "ounit2" {with-test}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/test/dune
+++ b/test/dune
@@ -1,6 +1,5 @@
 (test
  (name pcre_tests)
- (preprocess (pps ppx_deriving.show))
  (libraries pcre ounit2))
 
 (env

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,9 @@
+(test
+ (name pcre_tests)
+ (preprocess (pps ppx_deriving.show))
+ (libraries pcre ounit2))
+
+(env
+ (dev
+  (flags
+   (:standard -w -27))))

--- a/test/pcre_tests.ml
+++ b/test/pcre_tests.ml
@@ -492,9 +492,14 @@ let test_pcre_subst ctxt =
        ~subst:(fun __g__ -> String.concat "" ["$"]) "abcabc")
 
 
+let show_string_option =
+  function
+    None -> "None"
+  | Some s -> Printf.sprintf "Some %s" s
+
 let test_pcre_ocamlfind_bits ctxt =
   ();
-  assert_equal ~printer:[%show: string option] (Some "-syntax camlp5o ")
+  assert_equal ~printer:show_string_option (Some "-syntax camlp5o ")
     (snd
        ((let __re__ = Pcre.regexp ~flags:[] "^\\(\\*\\*pp (.*?)\\*\\)" in
          fun __subj__ ->

--- a/test/pcre_tests.ml
+++ b/test/pcre_tests.ml
@@ -436,86 +436,6 @@ let test_pcre_delim_split_raw ctxt =
   end
 
 
-let test_pcre_string_pattern ctxt =
-  ();
-  assert_equal "$b"
-    ((fun __g__ ->
-        String.concat ""
-          ["$"; "";
-           match Pcre.get_substring __g__ 1 with
-             exception Not_found -> ""
-           | s -> s])
-       ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
-         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
-          "abc"));
-  assert_equal "b"
-    ((fun __g__ ->
-        String.concat ""
-          [match Pcre.get_substring __g__ 01 with
-             exception Not_found -> ""
-           | s -> s])
-       ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
-         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
-          "abc"));
-  assert_equal "bx"
-    (let s = "x" in
-     (fun __g__ ->
-        String.concat ""
-          [begin match Pcre.get_substring __g__ 01 with
-             exception Not_found -> ""
-           | s -> s
-           end;
-           ""; s])
-       ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
-         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
-          "abc"));
-  assert_equal "\"bx"
-    (let s = "x" in
-     (fun __g__ ->
-        String.concat ""
-          ["\"";
-           begin match Pcre.get_substring __g__ 01 with
-             exception Not_found -> ""
-           | s -> s
-           end;
-           ""; s])
-       ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
-         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
-          "abc"));
-  assert_equal "\"x" (let s = "x" in String.concat "" ["\""; s])
-
-
-let test_pcre_expr_pattern ctxt =
-  ();
-  assert_equal "abc"
-    ((fun __g__ ->
-        match Pcre.get_substring __g__ 0 with
-          exception Not_found -> ""
-        | s -> s)
-       ((let __re__ = Pcre.regexp ~flags:[] "abc" in
-         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
-          "abc"));
-  assert_equal "abcx"
-    ((fun __g__ ->
-        (match Pcre.get_substring __g__ 0 with
-           exception Not_found -> ""
-         | s -> s) ^
-        "x")
-       ((let __re__ = Pcre.regexp ~flags:[] "abc" in
-         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
-          "abc"));
-  assert_equal "abcx"
-    (let x = "x" in
-     (fun __g__ ->
-        (match Pcre.get_substring __g__ 0 with
-           exception Not_found -> ""
-         | s -> s) ^
-        x)
-       ((let __re__ = Pcre.regexp ~flags:[] "abc" in
-         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
-          "abc"));
-  assert_equal "x" (let x = "x" in "" ^ x)
-
 let test_pcre_subst ctxt =
   ();
   assert_equal "$b"
@@ -622,8 +542,6 @@ let suite =
      "pcre multiline" >:: test_pcre_multiline;
      "pcre simple_split" >:: test_pcre_simple_split;
      "pcre delim_split raw" >:: test_pcre_delim_split_raw;
-     "pcre string_pattern" >:: test_pcre_string_pattern;
-     "pcre expr_pattern" >:: test_pcre_expr_pattern;
      "pcre subst" >:: test_pcre_subst;
      "pcre ocamlfind bits" >:: test_pcre_ocamlfind_bits;
      "pcre envsubst via replace" >:: test_pcre_envsubst_via_replace;

--- a/test/pcre_tests.ml
+++ b/test/pcre_tests.ml
@@ -1,0 +1,633 @@
+(**pp -syntax camlp5o -package pa_ppx.deriving_plugins.std *)
+open OUnit2
+
+
+
+let test_special_char_regexps ctxt =
+  ();
+  assert_equal "\n"
+    ((let __re__ = Pcre.regexp ~flags:[`DOTALL] "\\n$" in
+      fun __subj__ ->
+        (fun __g__ -> Pcre.get_substring __g__ 0)
+          (Pcre.exec ~rex:__re__ __subj__))
+       "\n");
+  assert_equal ""
+    (Pcre.substitute_substrings_first
+       ~rex:(Pcre.regexp ~flags:[`DOTALL] "\\n+$")
+       ~subst:(fun __g__ -> String.concat "" []) "\n\n")
+
+let test_pcre_simple_match ctxt =
+  ();
+  assert_equal "abc"
+    (Pcre.get_substring
+       ((let __re__ = Pcre.regexp ~flags:[] "abc" in
+         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
+          "abc")
+       0);
+  assert_equal (Some "abc")
+    ((let __re__ = Pcre.regexp ~flags:[] "abc" in
+      fun __subj__ ->
+        match
+          Option.map (fun __g__ -> Pcre.get_substring __g__ 0)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "abc");
+  assert_equal (Some "abc")
+    ((let __re__ = Pcre.regexp ~flags:[] "abc" in
+      fun __subj__ ->
+        match
+          Option.map (fun __g__ -> Pcre.get_substring __g__ 0)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "abc");
+  assert_equal true
+    ((let __re__ = Pcre.regexp ~flags:[] "abc" in
+      fun __subj__ -> Pcre.pmatch ~rex:__re__ __subj__)
+       "abc");
+  assert_equal false
+    ((let __re__ = Pcre.regexp ~flags:[] "abc" in
+      fun __subj__ -> Pcre.pmatch ~rex:__re__ __subj__)
+       "abd");
+  assert_equal None
+    ((let __re__ = Pcre.regexp ~flags:[] "abc" in
+      fun __subj__ ->
+        match
+          Option.map (fun __g__ -> Pcre.get_substring __g__ 0)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "abd");
+  assert_raises Not_found
+    (fun () ->
+       (let __re__ = Pcre.regexp ~flags:[] "abc" in
+        fun __subj__ ->
+          (fun __g__ -> Pcre.get_substring __g__ 0)
+            (Pcre.exec ~rex:__re__ __subj__))
+         "abd");
+  assert_raises Not_found
+    (fun () ->
+       (let __re__ = Pcre.regexp ~flags:[] "abc" in
+        fun __subj__ ->
+          (fun __g__ -> Pcre.get_substring __g__ 0)
+            (Pcre.exec ~rex:__re__ __subj__))
+         "abd");
+  assert_equal None
+    ((let __re__ = Pcre.regexp ~flags:[] "abc" in
+      fun __subj__ ->
+        match
+          Option.map (fun __g__ -> Pcre.get_substring __g__ 0)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "abd");
+  assert_equal "abc"
+    ((let __re__ = Pcre.regexp ~flags:[] "abc" in
+      fun __subj__ ->
+        (fun __g__ -> Pcre.get_substring __g__ 0)
+          (Pcre.exec ~rex:__re__ __subj__))
+       "abc");
+  assert_equal ("abc", Some "b")
+    ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
+      fun __subj__ ->
+        (fun __g__ ->
+           Pcre.get_substring __g__ 0,
+           (try Some (Pcre.get_substring __g__ 1) with Not_found -> None))
+          (Pcre.exec ~rex:__re__ __subj__))
+       "abc");
+  assert_equal ("ac", None)
+    ((let __re__ = Pcre.regexp ~flags:[] "a(?:(b)?)c" in
+      fun __subj__ ->
+        (fun __g__ ->
+           Pcre.get_substring __g__ 0,
+           (try Some (Pcre.get_substring __g__ 1) with Not_found -> None))
+          (Pcre.exec ~rex:__re__ __subj__))
+       "ac");
+  assert_equal "abc"
+    (Pcre.get_substring
+       ((let __re__ = Pcre.regexp ~flags:[`CASELESS] "ABC" in
+         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
+          "abc")
+       0);
+  assert_equal ("abc", Some "a", Some "b", Some "c")
+    ((let __re__ = Pcre.regexp ~flags:[] "(a)(b)(c)" in
+      fun __subj__ ->
+        (fun __g__ ->
+           Pcre.get_substring __g__ 0,
+           (try Some (Pcre.get_substring __g__ 1) with Not_found -> None),
+           (try Some (Pcre.get_substring __g__ 2) with Not_found -> None),
+           (try Some (Pcre.get_substring __g__ 3) with Not_found -> None))
+          (Pcre.exec ~rex:__re__ __subj__))
+       "abc")
+
+let test_pcre_selective_match ctxt =
+  ();
+  assert_equal ("abc", Some "b")
+    ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
+      fun __subj__ ->
+        (fun __g__ ->
+           Pcre.get_substring __g__ 0,
+           (try Some (Pcre.get_substring __g__ 1) with Not_found -> None))
+          (Pcre.exec ~rex:__re__ __subj__))
+       "abc");
+  assert_equal ("abc", "b")
+    ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
+      fun __subj__ ->
+        (fun __g__ -> Pcre.get_substring __g__ 0, Pcre.get_substring __g__ 1)
+          (Pcre.exec ~rex:__re__ __subj__))
+       "abc");
+  assert_equal "b"
+    ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
+      fun __subj__ ->
+        (fun __g__ -> Pcre.get_substring __g__ 1)
+          (Pcre.exec ~rex:__re__ __subj__))
+       "abc");
+  assert_equal (Some ("abc", "b"))
+    ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
+      fun __subj__ ->
+        match
+          Option.map
+            (fun __g__ ->
+               Pcre.get_substring __g__ 0, Pcre.get_substring __g__ 1)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "abc");
+  assert_equal ("ac", None)
+    ((let __re__ = Pcre.regexp ~flags:[] "a(b)?c" in
+      fun __subj__ ->
+        (fun __g__ ->
+           Pcre.get_substring __g__ 0,
+           (try Some (Pcre.get_substring __g__ 1) with Not_found -> None))
+          (Pcre.exec ~rex:__re__ __subj__))
+       "ac");
+  assert_raises Not_found
+    (fun _ ->
+       (let __re__ = Pcre.regexp ~flags:[] "a(b)?c" in
+        fun __subj__ ->
+          (fun __g__ ->
+             Pcre.get_substring __g__ 0, Pcre.get_substring __g__ 1)
+            (Pcre.exec ~rex:__re__ __subj__))
+         "ac");
+  assert_equal None
+    ((let __re__ = Pcre.regexp ~flags:[] "a(b)?c" in
+      fun __subj__ ->
+        match
+          Option.map
+            (fun __g__ ->
+               Pcre.get_substring __g__ 0, Pcre.get_substring __g__ 1)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "ac")
+
+let test_pcre_search ctxt =
+  ();
+  assert_equal "abc"
+    ((let __re__ = Pcre.regexp ~flags:[] "abc" in
+      fun __subj__ ->
+        (fun __g__ -> Pcre.get_substring __g__ 0)
+          (Pcre.exec ~rex:__re__ __subj__))
+       "zzzabc");
+  assert_equal None
+    ((let __re__ = Pcre.regexp ~flags:[] "^abc" in
+      fun __subj__ ->
+        match
+          Option.map (fun __g__ -> Pcre.get_substring __g__ 0)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "zzzabc")
+
+
+let test_pcre_single ctxt =
+  ();
+  assert_equal None
+    ((let __re__ = Pcre.regexp ~flags:[] ".+" in
+      fun __subj__ ->
+        match
+          Option.map (fun __g__ -> Pcre.get_substring __g__ 0)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "\n\n");
+  assert_equal "\n\n"
+    ((let __re__ = Pcre.regexp ~flags:[`DOTALL] ".+" in
+      fun __subj__ ->
+        (fun __g__ -> Pcre.get_substring __g__ 0)
+          (Pcre.exec ~rex:__re__ __subj__))
+       "\n\n");
+  assert_equal None
+    ((let __re__ = Pcre.regexp ~flags:[`MULTILINE] ".+" in
+      fun __subj__ ->
+        match
+          Option.map (fun __g__ -> Pcre.get_substring __g__ 0)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "\n\n");
+  assert_equal None
+    ((let __re__ = Pcre.regexp ~flags:[] ".+" in
+      fun __subj__ ->
+        match
+          Option.map (fun __g__ -> Pcre.get_substring __g__ 0)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "\n\n");
+  assert_equal (Some "\n\n")
+    ((let __re__ = Pcre.regexp ~flags:[`DOTALL] ".+" in
+      fun __subj__ ->
+        match
+          Option.map (fun __g__ -> Pcre.get_substring __g__ 0)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "\n\n");
+  assert_equal None
+    ((let __re__ = Pcre.regexp ~flags:[`MULTILINE] ".+" in
+      fun __subj__ ->
+        match
+          Option.map (fun __g__ -> Pcre.get_substring __g__ 0)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "\n\n");
+  assert_equal "<<abc>>\ndef"
+    (Pcre.substitute_substrings_first ~rex:(Pcre.regexp ~flags:[] ".+")
+       ~subst:(fun __g__ ->
+          String.concat ""
+            ["<<";
+             begin match Pcre.get_substring __g__ 0 with
+               exception Not_found -> ""
+             | s -> s
+             end;
+             ">>"])
+       "abc\ndef");
+  assert_equal "<<abc\ndef>>"
+    (Pcre.substitute_substrings_first ~rex:(Pcre.regexp ~flags:[`DOTALL] ".+")
+       ~subst:(fun __g__ ->
+          String.concat ""
+            ["<<";
+             begin match Pcre.get_substring __g__ 0 with
+               exception Not_found -> ""
+             | s -> s
+             end;
+             ">>"])
+       "abc\ndef");
+  assert_equal "<<abc>>\ndef"
+    (Pcre.substitute_substrings_first
+       ~rex:(Pcre.regexp ~flags:[`MULTILINE] ".+")
+       ~subst:(fun __g__ ->
+          String.concat ""
+            ["<<";
+             begin match Pcre.get_substring __g__ 0 with
+               exception Not_found -> ""
+             | s -> s
+             end;
+             ">>"])
+       "abc\ndef");
+  assert_equal "<<abc>>\ndef"
+    (Pcre.substitute_substrings_first ~rex:(Pcre.regexp ~flags:[] ".*")
+       ~subst:(fun __g__ ->
+          String.concat ""
+            ["<<";
+             begin match Pcre.get_substring __g__ 0 with
+               exception Not_found -> ""
+             | s -> s
+             end;
+             ">>"])
+       "abc\ndef");
+  assert_equal "<<abc>><<>>\n<<def>><<>>"
+    (Pcre.substitute_substrings ~rex:(Pcre.regexp ~flags:[] ".*")
+       ~subst:(fun __g__ ->
+          String.concat ""
+            ["<<";
+             begin match Pcre.get_substring __g__ 0 with
+               exception Not_found -> ""
+             | s -> s
+             end;
+             ">>"])
+       "abc\ndef");
+  assert_equal "<<abc>>\n<<def>>"
+    (Pcre.substitute_substrings ~rex:(Pcre.regexp ~flags:[] ".+")
+       ~subst:(fun __g__ ->
+          String.concat ""
+            ["<<";
+             begin match Pcre.get_substring __g__ 0 with
+               exception Not_found -> ""
+             | s -> s
+             end;
+             ">>"])
+       "abc\ndef");
+  assert_equal "<<abc>>a\nc<<aec>>"
+    (Pcre.substitute_substrings ~rex:(Pcre.regexp ~flags:[] "a.c")
+       ~subst:(fun __g__ ->
+          String.concat ""
+            ["<<";
+             begin match Pcre.get_substring __g__ 0 with
+               exception Not_found -> ""
+             | s -> s
+             end;
+             ">>"])
+       "abca\ncaec");
+  assert_equal "<<abc>><<a\nc>><<aec>>"
+    (Pcre.substitute_substrings ~rex:(Pcre.regexp ~flags:[`DOTALL] "a.c")
+       ~subst:(fun __g__ ->
+          String.concat ""
+            ["<<";
+             begin match Pcre.get_substring __g__ 0 with
+               exception Not_found -> ""
+             | s -> s
+             end;
+             ">>"])
+       "abca\ncaec")
+
+let test_pcre_multiline ctxt =
+  ();
+  assert_equal (Some "bar")
+    ((let __re__ = Pcre.regexp ~flags:[] ".+$" in
+      fun __subj__ ->
+        match
+          Option.map (fun __g__ -> Pcre.get_substring __g__ 0)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "foo\nbar");
+  assert_equal (Some "foo")
+    ((let __re__ = Pcre.regexp ~flags:[`MULTILINE] ".+$" in
+      fun __subj__ ->
+        match
+          Option.map (fun __g__ -> Pcre.get_substring __g__ 0)
+            (try Some (Pcre.exec ~rex:__re__ __subj__) with Not_found -> None)
+        with
+          exception Not_found -> None
+        | rv -> rv)
+       "foo\nbar")
+
+let test_pcre_simple_split ctxt =
+  ();
+  assert_equal ["bb"]
+    ((let __re__ = Pcre.regexp ~flags:[] "a" in
+      fun __subj__ -> Pcre.split ~rex:__re__ __subj__)
+       "bb")
+
+
+let test_pcre_delim_split_raw ctxt =
+  let open Pcre in
+  begin
+    ();
+    assert_equal [Delim "a"; Text "b"; Delim "a"; Text "b"]
+      ((let __re__ = Pcre.regexp ~flags:[] "a" in
+        fun __subj__ -> Pcre.full_split ~rex:__re__ __subj__)
+         "ababa");
+    assert_equal [Delim "a"; Text "b"; Delim "a"; Delim "a"; Text "b"]
+      ((let __re__ = Pcre.regexp ~flags:[] "a" in
+        fun __subj__ -> Pcre.full_split ~rex:__re__ __subj__)
+         "abaaba");
+    assert_equal
+      [Delim "a"; NoGroup; Text "b"; Delim "ac"; Group (1, "c"); Text "b";
+       Delim "a"; NoGroup]
+      ((let __re__ = Pcre.regexp ~flags:[] "a(c)?" in
+        fun __subj__ -> Pcre.full_split ~rex:__re__ __subj__)
+         "abacba");
+    assert_equal
+      [Delim "ac"; Group (1, "c"); Text "b"; Delim "ac"; Group (1, "c");
+       Text "b"; Delim "ac"; Group (1, "c")]
+      ((let __re__ = Pcre.regexp ~flags:[] "a(c)" in
+        fun __subj__ -> Pcre.full_split ~rex:__re__ __subj__)
+         "acbacbac");
+    assert_equal
+      [Delim "ac"; Group (1, "c"); Text "b"; Delim "ac"; Group (1, "c");
+       Text "b"; Delim "ac"; Group (1, "c")]
+      ((let __re__ = Pcre.regexp ~flags:[] "a(c)" in
+        fun __subj__ -> Pcre.full_split ~rex:__re__ __subj__)
+         "acbacbac");
+    assert_equal
+      [Delim "a"; NoGroup; Text "b"; Delim "ac"; Group (1, "c"); Text "b";
+       Delim "a"; NoGroup]
+      ((let __re__ = Pcre.regexp ~flags:[] "a(c)?" in
+        fun __subj__ -> Pcre.full_split ~rex:__re__ __subj__)
+         "abacba");
+    assert_equal [Text "ab"; Delim "x"; Group (1, "x"); NoGroup; Text "cd"]
+      ((let __re__ = Pcre.regexp ~flags:[] "(x)|(u)" in
+        fun __subj__ -> Pcre.full_split ~rex:__re__ __subj__)
+         "abxcd");
+    assert_equal
+      [Text "ab"; Delim "x"; Group (1, "x"); NoGroup; Text "cd"; Delim "u";
+       NoGroup; Group (2, "u")]
+      ((let __re__ = Pcre.regexp ~flags:[] "(x)|(u)" in
+        fun __subj__ -> Pcre.full_split ~rex:__re__ __subj__)
+         "abxcdu")
+  end
+
+
+let test_pcre_string_pattern ctxt =
+  ();
+  assert_equal "$b"
+    ((fun __g__ ->
+        String.concat ""
+          ["$"; "";
+           match Pcre.get_substring __g__ 1 with
+             exception Not_found -> ""
+           | s -> s])
+       ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
+         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
+          "abc"));
+  assert_equal "b"
+    ((fun __g__ ->
+        String.concat ""
+          [match Pcre.get_substring __g__ 01 with
+             exception Not_found -> ""
+           | s -> s])
+       ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
+         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
+          "abc"));
+  assert_equal "bx"
+    (let s = "x" in
+     (fun __g__ ->
+        String.concat ""
+          [begin match Pcre.get_substring __g__ 01 with
+             exception Not_found -> ""
+           | s -> s
+           end;
+           ""; s])
+       ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
+         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
+          "abc"));
+  assert_equal "\"bx"
+    (let s = "x" in
+     (fun __g__ ->
+        String.concat ""
+          ["\"";
+           begin match Pcre.get_substring __g__ 01 with
+             exception Not_found -> ""
+           | s -> s
+           end;
+           ""; s])
+       ((let __re__ = Pcre.regexp ~flags:[] "a(b)c" in
+         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
+          "abc"));
+  assert_equal "\"x" (let s = "x" in String.concat "" ["\""; s])
+
+
+let test_pcre_expr_pattern ctxt =
+  ();
+  assert_equal "abc"
+    ((fun __g__ ->
+        match Pcre.get_substring __g__ 0 with
+          exception Not_found -> ""
+        | s -> s)
+       ((let __re__ = Pcre.regexp ~flags:[] "abc" in
+         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
+          "abc"));
+  assert_equal "abcx"
+    ((fun __g__ ->
+        (match Pcre.get_substring __g__ 0 with
+           exception Not_found -> ""
+         | s -> s) ^
+        "x")
+       ((let __re__ = Pcre.regexp ~flags:[] "abc" in
+         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
+          "abc"));
+  assert_equal "abcx"
+    (let x = "x" in
+     (fun __g__ ->
+        (match Pcre.get_substring __g__ 0 with
+           exception Not_found -> ""
+         | s -> s) ^
+        x)
+       ((let __re__ = Pcre.regexp ~flags:[] "abc" in
+         fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
+          "abc"));
+  assert_equal "x" (let x = "x" in "" ^ x)
+
+let test_pcre_subst ctxt =
+  ();
+  assert_equal "$b"
+    (Pcre.substitute_substrings_first ~rex:(Pcre.regexp ~flags:[] "a(b)c")
+       ~subst:(fun __g__ ->
+          String.concat ""
+            ["$"; "";
+             match Pcre.get_substring __g__ 1 with
+               exception Not_found -> ""
+             | s -> s])
+       "abc");
+  assert_equal "$b"
+    (Pcre.substitute_substrings_first
+       ~rex:(Pcre.regexp ~flags:[`CASELESS] "A(B)C")
+       ~subst:(fun __g__ ->
+          String.concat ""
+            ["$"; "";
+             match Pcre.get_substring __g__ 1 with
+               exception Not_found -> ""
+             | s -> s])
+       "abc");
+  assert_equal "$babc"
+    (Pcre.substitute_substrings_first
+       ~rex:(Pcre.regexp ~flags:[`CASELESS] "A(B)C")
+       ~subst:(fun __g__ ->
+          String.concat ""
+            ["$"; "";
+             match Pcre.get_substring __g__ 1 with
+               exception Not_found -> ""
+             | s -> s])
+       "abcabc");
+  assert_equal "$b$b"
+    (Pcre.substitute_substrings ~rex:(Pcre.regexp ~flags:[`CASELESS] "A(B)C")
+       ~subst:(fun __g__ ->
+          String.concat ""
+            ["$"; "";
+             match Pcre.get_substring __g__ 1 with
+               exception Not_found -> ""
+             | s -> s])
+       "abcabc");
+  assert_equal "$b$b"
+    (Pcre.substitute_substrings ~rex:(Pcre.regexp ~flags:[`CASELESS] "A(B)C")
+       ~subst:(fun __g__ ->
+          "$" ^
+          (match Pcre.get_substring __g__ 1 with
+             exception Not_found -> ""
+           | s -> s))
+       "abcabc");
+  assert_equal "$$"
+    (Pcre.substitute_substrings ~rex:(Pcre.regexp ~flags:[`CASELESS] "A(B)C")
+       ~subst:(fun __g__ -> "$") "abcabc");
+  assert_equal "$$"
+    (Pcre.substitute_substrings ~rex:(Pcre.regexp ~flags:[`CASELESS] "A(B)C")
+       ~subst:(fun __g__ -> String.concat "" ["$"]) "abcabc")
+
+
+let test_pcre_ocamlfind_bits ctxt =
+  ();
+  assert_equal ~printer:[%show: string option] (Some "-syntax camlp5o ")
+    (snd
+       ((let __re__ = Pcre.regexp ~flags:[] "^\\(\\*\\*pp (.*?)\\*\\)" in
+         fun __subj__ ->
+           (fun __g__ ->
+              Pcre.get_substring __g__ 0,
+              (try Some (Pcre.get_substring __g__ 1) with Not_found -> None))
+             (Pcre.exec ~rex:__re__ __subj__))
+          "(**pp -syntax camlp5o *)\n"))
+
+let pcre_envsubst envlookup s =
+  let f s1 s2 =
+    if s1 <> "" then envlookup s1
+    else if s2 <> "" then envlookup s2
+    else assert false
+  in
+  Pcre.substitute_substrings
+    ~rex:(Pcre.regexp ~flags:[] "(?:\\$\\(([^)]+)\\)|\\$\\{([^}]+)\\})")
+    ~subst:(fun __g__ ->
+       f
+         (match Pcre.get_substring __g__ 1 with
+            exception Not_found -> ""
+          | s -> s)
+         (match Pcre.get_substring __g__ 2 with
+            exception Not_found -> ""
+          | s -> s))
+    s
+
+let test_pcre_envsubst_via_replace ctxt =
+  let f =
+    function
+      "A" -> "res1"
+    | "B" -> "res2"
+    | _ -> failwith "unexpected arg in envsubst"
+  in
+  assert_equal "...res1...res2..." (pcre_envsubst f "...$(A)...${B}...")
+
+
+
+
+
+let suite =
+  "Test pa_ppx_regexp" >:::
+    ["pcre selective_match" >:: test_pcre_selective_match;
+     "pcre search" >:: test_pcre_search; "pcre single" >:: test_pcre_single;
+     "pcre multiline" >:: test_pcre_multiline;
+     "pcre simple_split" >:: test_pcre_simple_split;
+     "pcre delim_split raw" >:: test_pcre_delim_split_raw;
+     "pcre string_pattern" >:: test_pcre_string_pattern;
+     "pcre expr_pattern" >:: test_pcre_expr_pattern;
+     "pcre subst" >:: test_pcre_subst;
+     "pcre ocamlfind bits" >:: test_pcre_ocamlfind_bits;
+     "pcre envsubst via replace" >:: test_pcre_envsubst_via_replace;
+     "pcre only_regexps" >:: test_special_char_regexps]
+
+let _ = if not !(Sys.interactive) then run_test_tt_main suite
+


### PR DESCRIPTION
Markus, here's a PR where I copied over tests from `pa_ppx_regexp`, removed all the ones that use `re` and `pcre2`, and those that didn't actually test `pcre` functionality.  This is necessarily going to be incomplete, and probably tests things more than once, but I thought I should at least start someplace, and this is someplace *grin*.

Let me know if this is the direction you'd like to go in, and then we can discuss what to remove, and what other areas of functionality need to be tested.

The way this works, is that in `pa_ppx_test` there is source that needs to be expanded using `pa_ppx_regexp`; then that expanded source is copied into `test`.  That is the test source, that gets released, etc.  Whenever the original source in `pa_ppx_test` is changed, the "bootstrap" process regenerates the test source in `test`.  But the test itself doesn't depend on `pa_ppx_regexp`, hence doesn't need anything from camlp5 to build/run.

This means that the tests can use a ton of verbose `pcre` stuff, without it being a pain to maintain (at least, for me, which is why I wrote `pa_ppx_regexp`).

Hope this is clear; if not, I can try to explain better.