### PR TITLE
make caml_alloc_some private

### DIFF
--- a/lib/pcre_stubs.c
+++ b/lib/pcre_stubs.c
@@ -55,7 +55,7 @@ typedef long *caml_int_ptr;
 #define Val_none (Val_long(0))
 #define Is_none(v) ((v) == Val_none)
 
-CAMLexport value caml_alloc_some(value v) {
+CAMLexport static value caml_alloc_some(value v) {
   CAMLparam1(v);
   value some = caml_alloc_small(1, 0);
   Field(some, 0) = v;


### PR DESCRIPTION
so that if other C FFI packages define the same, they won't conflict in the linker.

I got that error when I linked bothe pcre and pcre2 in the same executable.  I fixed the error in pcre2, but figured you might want to fix it here also.