### PR TITLE
pcre_stubs.c: Squelch uninitialized-value warnings

### DIFF
--- a/lib/pcre_stubs.c
+++ b/lib/pcre_stubs.c
@@ -627,8 +627,8 @@ CAMLprim value pcre_exec_stub0(intnat v_opt, value v_rex, intnat v_pos,
       value v_substrings;
       char *subj = caml_stat_alloc(sizeof(char) * len);
       int *ovec = caml_stat_alloc(sizeof(int) * ovec_len);
-      int workspace_len;
-      int *workspace;
+      int workspace_len = Wosize_val(v_workspace);
+      int *workspace = NULL;
       struct cod cod = {0, (value *)NULL, (value *)NULL, (value)NULL};
       struct pcre_extra new_extra =
 #ifdef PCRE_EXTRA_MATCH_LIMIT_RECURSION
@@ -671,7 +671,6 @@ CAMLprim value pcre_exec_stub0(intnat v_opt, value v_rex, intnat v_pos,
       }
 
       if (is_dfa) {
-        workspace_len = Wosize_val(v_workspace);
         workspace = caml_stat_alloc(sizeof(int) * workspace_len);
         ret = pcre_dfa_exec(code, extra, subj, len, pos, opt, ovec, ovec_len,
                             (int *)&Field(v_workspace, 0), workspace_len);


### PR DESCRIPTION
While building with gcc 15.1.0, I get the following warnings:

```
pcre2_stubs.c: In function ‘pcre2_match_stub0’:
pcre2_stubs.c:601:53: warning: ‘workspace_len’ may be used uninitialized [-Wmaybe-uninitialized]
  601 |           const int *workspace_src_stop = workspace + workspace_len;
      |                                                     ^
pcre2_stubs.c:554:11: note: ‘workspace_len’ was declared here
  554 |       int workspace_len;
      |           ^~~~~~~~~~~~~
pcre2_stubs.c:601:22: warning: ‘workspace’ may be used uninitialized [-Wmaybe-uninitialized]
  601 |           const int *workspace_src_stop = workspace + workspace_len;
      |                      ^~~~~~~~~~~~~~~~~~
pcre2_stubs.c:555:12: note: ‘workspace’ was declared here
  555 |       int *workspace;
      |            ^~~~~~~~~
```

I believe these warnings are spurious, in the sense that `workspace` and `workspace_len` are accessed only along code paths where `is_dfa` is true, and they seem to be properly initialised in those scenarios.  However, the warning persists.  This patch simply assigns values to those variables at declaration-time so the warning goes away.  (`Wosize_val` [expands out](https://github.com/ocaml/ocaml/blob/12ea618e22add7047ac3e09d2fa5a07ea42d52d9/runtime/caml/mlvalues.h#L162C1-L163C62) to just a few bitwise operations, so there is no runtime impact of evaluating that expression in code paths where `is_dfa` is false.)

Thanks for maintaining this project!

Nathan