### PR TITLE
Fix crash introduced in PR #35

### DIFF
--- a/lib/pcre_stubs.c
+++ b/lib/pcre_stubs.c
@@ -627,7 +627,7 @@ CAMLprim value pcre_exec_stub0(intnat v_opt, value v_rex, intnat v_pos,
       value v_substrings;
       char *subj = caml_stat_alloc(sizeof(char) * len);
       int *ovec = caml_stat_alloc(sizeof(int) * ovec_len);
-      int workspace_len = Wosize_val(v_workspace);
+      int workspace_len = 0;
       int *workspace = NULL;
       struct cod cod = {0, (value *)NULL, (value *)NULL, (value)NULL};
       struct pcre_extra new_extra =
@@ -671,6 +671,7 @@ CAMLprim value pcre_exec_stub0(intnat v_opt, value v_rex, intnat v_pos,
       }
 
       if (is_dfa) {
+        workspace_len = Wosize_val(v_workspace);
         workspace = caml_stat_alloc(sizeof(int) * workspace_len);
         ret = pcre_dfa_exec(code, extra, subj, len, pos, opt, ovec, ovec_len,
                             (int *)&Field(v_workspace, 0), workspace_len);

--- a/test/pcre_tests.ml
+++ b/test/pcre_tests.ml
@@ -116,6 +116,13 @@ let test_pcre_simple_match ctxt =
          fun __subj__ -> Pcre.exec ~rex:__re__ __subj__)
           "abc")
        0);
+  assert_equal "abc"
+    (Pcre.get_substring
+       ((let __re__ = Pcre.regexp "abc" in
+         (* Explicitly adding a dummy callout to validate PR #36 *)
+         fun __subj__ -> Pcre.exec ~callout:(fun _ -> ()) ~rex:__re__ __subj__)
+          "abc")
+       0);
   assert_equal
     ("abc", Some "a", Some "b", Some "c")
     ((let __re__ = Pcre.regexp ~flags:[] "(a)(b)(c)" in


### PR DESCRIPTION
Pull request #35 was intended to simply silence "uninitialised value" warnings. However, I, the author of that patch, misread which macro is used to compute the value for `workspace_len` (in the PR description I allude to `Wosize_val`, but link to the definition of a different macro.).  As a result, when `is_dfa` is false, a NULL pointer read occurs.  This patch undoes this breakage; `Wosize_val(v_workspace)` is now only evaluated on code paths where `is_dfa` is true.

I apologise for introducing this breaking change.