### PR TITLE
README: odig pcre, not pcre2

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Reasons to choose PCRE-OCaml:
 Please run:
 
 ```sh
-odig odoc pcre2
+odig odoc pcre
 ```
 
 Or:


### PR DESCRIPTION
This lib is pcre, not pcre2. The odig invocation seems incorrect.